### PR TITLE
商品詳細ページ　サーバーサイド実装

### DIFF
--- a/app/assets/javascripts/show-image.js
+++ b/app/assets/javascripts/show-image.js
@@ -1,7 +1,5 @@
 $(function(){
-  // 「imageList」内の「img」をマウスオーバーした場合
   $('#is__photo__place__dots img').hover(function(){
-      // マウスオーバーしている画像をメインの画像に反映
       $('.is__photo__place__sample__stage__in__img img').attr('src', $(this).attr('src'));
   });
 });

--- a/app/assets/javascripts/show-image.js
+++ b/app/assets/javascripts/show-image.js
@@ -1,0 +1,7 @@
+$(function(){
+  // 「imageList」内の「img」をマウスオーバーした場合
+  $('#is__photo__place__dots img').hover(function(){
+      // マウスオーバーしている画像をメインの画像に反映
+      $('.is__photo__place__sample__stage__in__img img').attr('src', $(this).attr('src'));
+  });
+});

--- a/app/assets/stylesheets/modules/show.scss
+++ b/app/assets/stylesheets/modules/show.scss
@@ -14,7 +14,7 @@
     line-height: 1.4;
   }
   &__main-content {
-    height: 420px;
+    height: 480px;
     margin: 16px 0 0;
     &:after {
       content: "";
@@ -122,12 +122,16 @@
   }
   &__price-box {
     margin: 24px 0 0;
-    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
     .is-item-price-large {
+      display: inline-block;
       margin: 0 16px 0 0;
       font-size: 50px;
     }
     .is-item-tax {
+      display: inline-block;
       font-size: 10px;
     }
     .is-item-stopfee {

--- a/app/assets/stylesheets/modules/show.scss
+++ b/app/assets/stylesheets/modules/show.scss
@@ -55,6 +55,7 @@
         display: none;
       }
       &__dots {
+        margin-top: 8px;
         line-height: 0;
         &__inner {
           width: 60px;
@@ -91,6 +92,7 @@
     .is__table-data {
       margin: 0;
       width: 61%;
+      padding: 0 8px;
       background: #fff;
       &__category {
         display: block;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,6 +4,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,6 +5,8 @@ class ItemsController < ApplicationController
 
   def show
     @item = Item.find(params[:id])
+    @saler_other_items = Item.where(saler_id: @item.saler.id) 
+    @same_category_items = Item.where(category_id: @item.category.id)
   end
 
   def new

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,38 +1,22 @@
 .wrapper
 
-  = render 'layouts/header1'
+  = render 'shared/header1'
 
 
 
   .is-item-box
-    %h1.is-item-name 商品名
+    %h1.is-item-name 
+      = @item.name
     .is-item-box__main-content
 
       .is__photo
         .is__photo__place
           .is__photo__place__sample
             .is__photo__place__sample__stage
-              .is__photo__place__sample__stage__in
-                .is__photo__place__sample__stage__in__img
-                  = image_tag 'frema66img-sample1.jpeg'
-              .is__photo__place__sample__stage__in
-                .is__photo__place__sample__stage__in__img
-              .is__photo__place__sample__stage__in
-                .is__photo__place__sample__stage__in__img
-              .is__photo__place__sample__stage__in
-                .is__photo__place__sample__stage__in__img
-              .is__photo__place__sample__stage__in
-                .is__photo__place__sample__stage__in__img
-              .is__photo__place__sample__stage__in
-                .is__photo__place__sample__stage__in__img
-              .is__photo__place__sample__stage__in
-                .is__photo__place__sample__stage__in__img
-              .is__photo__place__sample__stage__in
-                .is__photo__place__sample__stage__in__img
-              .is__photo__place__sample__stage__in
-                .is__photo__place__sample__stage__in__img
-              .is__photo__place__sample__stage__in
-                .is__photo__place__sample__stage__in__img
+              - @item.images.each do |image|
+                .is__photo__place__sample__stage__in
+                  .is__photo__place__sample__stage__in__img
+                    = image_tag "#{image.source}", size: "300x300"
           .is__photo__place__disabled
           .is__photo__place__dots
             .is__photo__place__dots__inner
@@ -51,7 +35,8 @@
           %tr.is__table-record
             %th.is__table-header 出品者
             %td.is__table-data
-              .is__table-data__username お名前
+              .is__table-data__username 
+                = @item.saler.nickname
               .is__table__user-rating
                 = icon 'fas', 'laugh', class: 'is__table__user-rating__laugh'
               .is__table__user-rating
@@ -61,46 +46,57 @@
           %tr.is__table-record
             %th.is__table-header カテゴリー
             %td.is__table-data
-              = link_to "大カテゴリ", root_path, class: 'is__table-data__category'
+              = link_to root_path, class: 'is__table-data__category' do
+                = @item.category.parent.parent.name
               = link_to root_path, class: 'is__table-data__category' do
                 = icon 'fas', 'angle-right'
-                中カテゴリ
+                = @item.category.parent.name
               = link_to root_path, class: 'is__table-data__category' do
                 = icon 'fas', 'angle-right'
-                小カテゴリ
+                = @item.category.name
           %tr.is__table-record
             %th.is__table-header ブランド
-            %td.is__table-data #
+            %td.is__table-data 
+              = @item.brand_name
           %tr.is__table-record
             %th.is__table-header 商品のサイズ
-            %td.is__table-data #
+            %td.is__table-data 
+              = @item.size
           %tr.is__table-record
             %th.is__table-header 商品の状態
-            %td.is__table-data #
+            %td.is__table-data 
+              = @item.quolity
           %tr.is__table-record
             %th.is__table-header 配送料の負担
-            %td.is__table-data #
+            %td.is__table-data 
+              = @item.carriage_fee
           %tr.is__table-record
             %th.is__table-header 配送の方法
-            %td.is__table-data #
+            %td.is__table-data 
+              = @item.delivery
           %tr.is__table-record
             %th.is__table-header 配送元地域
             %td.is__table-data 
-              = link_to "都道府県名", root_path, class: 'is__table-data__enum'
+              = link_to "#{@item.prefecture}", root_path, class: 'is__table-data__enum'
           %tr.is__table-record
             %th.is__table-header 発送日の目安
-            %td.is__table-data #
+            %td.is__table-data 
+              = @item.days
 
     .is-item-box__price-box
-      %span.is-item-price-large ¥###
-      %span.is-item-tax （税込）
-      %span.is-item-stopfee 送料込みor着払い
+      .is-item-price-large 
+        ¥
+        = @item.price
+      .is-item-tax 
+        （税込）
+      .is-item-stopfee 
+        = @item.carriage_fee
 
     = link_to root_path , class: 'is-item-buy-btn' do
       購入画面に進む
 
     %p.is-item-box__error-message この商品はゆうゆうメルカリ便を利用しているため、アプリからのみ購入できます。
-
+    
     .is-item-box__description
       %p.is-item-box__description__inner ユーザーの商品説明が入る
 
@@ -109,7 +105,7 @@
         %button.is-button.is-button__like
           = icon 'far', 'heart', class: 'is-icon'
           %span.is__writing いいね！
-          %span.is__num num
+          %span.is__num 
         = link_to root_path, class: 'is-button is-button__report' do
           = icon 'far', 'flag', class: 'is-icon'
           %span.is__writing 不適切な商品の報告
@@ -265,6 +261,6 @@
 
 
 
-  = render 'layouts/footer1'
+  = render 'shared/footer1'
 
   -# = icon 'fas', 'angle-right'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -20,7 +20,7 @@
           .is__photo__place__disabled
           #is__photo__place__dots
             - @item.images.each do |image|
-              = image_tag "#{image.source}", size: "80x80"
+              = image_tag "#{image.source}", size: "60x60"
 
       %table.is__table
         %tbody
@@ -148,111 +148,37 @@
       %h2.is-user-items__others__name 
         = link_to "ユーザーさんのその他の出品", root_path
       .is-user-items__others__exhibit
-
-        %section.is-user-items__others__exhibit__boxes
-          = link_to root_path, class: 'is-user-items__others__exhibit__boxes__link' do
-            %figure.is-user-items__others__exhibit__boxes__photo
-              = image_tag 'frema66img-sample2.jpeg', class: 'is-user-items__others__exhibit__boxes__photo__img'
-            .is-user-items__others__exhibit__boxes__body
-              %h3.is-user-items__others__exhibit__boxes__body__name その他商品の名前
-              .is-user-items__others__exhibit__boxes__body__price ¥###
-
-        %section.is-user-items__others__exhibit__boxes
-          = link_to root_path, class: 'is-user-items__others__exhibit__boxes__link' do
-            %figure.is-user-items__others__exhibit__boxes__photo
-              = image_tag 'frema66img-sample2.jpeg', class: 'is-user-items__others__exhibit__boxes__photo__img'
-            .is-user-items__others__exhibit__boxes__body
-              %h3.is-user-items__others__exhibit__boxes__body__name その他商品の名前
-              .is-user-items__others__exhibit__boxes__body__price ¥###
-
-        %section.is-user-items__others__exhibit__boxes
-          = link_to root_path, class: 'is-user-items__others__exhibit__boxes__link' do
-            %figure.is-user-items__others__exhibit__boxes__photo
-              = image_tag 'frema66img-sample2.jpeg', class: 'is-user-items__others__exhibit__boxes__photo__img'
-            .is-user-items__others__exhibit__boxes__body
-              %h3.is-user-items__others__exhibit__boxes__body__name その他商品の名前
-              .is-user-items__others__exhibit__boxes__body__price ¥###
-
-        %section.is-user-items__others__exhibit__boxes
-          = link_to root_path, class: 'is-user-items__others__exhibit__boxes__link' do
-            %figure.is-user-items__others__exhibit__boxes__photo
-              = image_tag 'frema66img-sample2.jpeg', class: 'is-user-items__others__exhibit__boxes__photo__img'
-            .is-user-items__others__exhibit__boxes__body
-              %h3.is-user-items__others__exhibit__boxes__body__name その他商品の名前
-              .is-user-items__others__exhibit__boxes__body__price ¥###
-
-        %section.is-user-items__others__exhibit__boxes
-          = link_to root_path, class: 'is-user-items__others__exhibit__boxes__link' do
-            %figure.is-user-items__others__exhibit__boxes__photo
-              = image_tag 'frema66img-sample2.jpeg', class: 'is-user-items__others__exhibit__boxes__photo__img'
-            .is-user-items__others__exhibit__boxes__body
-              %h3.is-user-items__others__exhibit__boxes__body__name その他商品の名前
-              .is-user-items__others__exhibit__boxes__body__price ¥###
-
-        %section.is-user-items__others__exhibit__boxes
-          = link_to root_path, class: 'is-user-items__others__exhibit__boxes__link' do
-            %figure.is-user-items__others__exhibit__boxes__photo
-              = image_tag 'frema66img-sample2.jpeg', class: 'is-user-items__others__exhibit__boxes__photo__img'
-            .is-user-items__others__exhibit__boxes__body
-              %h3.is-user-items__others__exhibit__boxes__body__name その他商品の名前
-              .is-user-items__others__exhibit__boxes__body__price ¥###
-
-    %section.is-user-items__samegenre
-      %h2.is-user-items__others__name
-        = link_to "同一ジャンルのその他の出品", root_path
+        - @saler_other_items.each do |item| 
+          - if item.id != @item.id  # 現在表示している商品は関連に表示しない
+            %section.is-user-items__others__exhibit__boxes
+              = link_to item_path(item.id), class: 'is-user-items__others__exhibit__boxes__link' do
+                %figure.is-user-items__others__exhibit__boxes__photo
+                  - thumbnail = Image.find_by(item_id: item.id) # サムネイルとして商品の先頭に登録されている画像のみを取り出す
+                  = image_tag "#{thumbnail.source}", class: 'is-user-items__others__exhibit__boxes__photo__img'
+                .is-user-items__others__exhibit__boxes__body
+                  %h3.is-user-items__others__exhibit__boxes__body__name 
+                    = item.name
+                  .is-user-items__others__exhibit__boxes__body__price 
+                  ¥
+                  = item.price
+  .is-user-items
+    %section.is-user-items__others
+      %h2.is-user-items__others__name 
+        = link_to "同一ジャンルのその他の商品", root_path
       .is-user-items__others__exhibit
-
-        %section.is-user-items__others__exhibit__boxes
-          = link_to root_path, class: 'is-user-items__others__exhibit__boxes__link' do
-            %figure.is-user-items__others__exhibit__boxes__photo
-              = image_tag 'frema66img-sample3.jpeg', class: 'is-user-items__others__exhibit__boxes__photo__img'
-            .is-user-items__others__exhibit__boxes__body
-              %h3.is-user-items__others__exhibit__boxes__body__name その他商品の名前
-              .is-user-items__others__exhibit__boxes__body__price ¥###
-
-        %section.is-user-items__others__exhibit__boxes
-          = link_to root_path, class: 'is-user-items__others__exhibit__boxes__link' do
-            %figure.is-user-items__others__exhibit__boxes__photo
-              = image_tag 'frema66img-sample3.jpeg', class: 'is-user-items__others__exhibit__boxes__photo__img'
-            .is-user-items__others__exhibit__boxes__body
-              %h3.is-user-items__others__exhibit__boxes__body__name その他商品の名前
-              .is-user-items__others__exhibit__boxes__body__price ¥###
-
-        %section.is-user-items__others__exhibit__boxes
-          = link_to root_path, class: 'is-user-items__others__exhibit__boxes__link' do
-            %figure.is-user-items__others__exhibit__boxes__photo
-              = image_tag 'frema66img-sample3.jpeg', class: 'is-user-items__others__exhibit__boxes__photo__img'
-            .is-user-items__others__exhibit__boxes__body
-              %h3.is-user-items__others__exhibit__boxes__body__name その他商品の名前
-              .is-user-items__others__exhibit__boxes__body__price ¥###
-
-        %section.is-user-items__others__exhibit__boxes
-          = link_to root_path, class: 'is-user-items__others__exhibit__boxes__link' do
-            %figure.is-user-items__others__exhibit__boxes__photo
-              = image_tag 'frema66img-sample3.jpeg', class: 'is-user-items__others__exhibit__boxes__photo__img'
-            .is-user-items__others__exhibit__boxes__body
-              %h3.is-user-items__others__exhibit__boxes__body__name その他商品の名前
-              .is-user-items__others__exhibit__boxes__body__price ¥###
-
-        %section.is-user-items__others__exhibit__boxes
-          = link_to root_path, class: 'is-user-items__others__exhibit__boxes__link' do
-            %figure.is-user-items__others__exhibit__boxes__photo
-              = image_tag 'frema66img-sample3.jpeg', class: 'is-user-items__others__exhibit__boxes__photo__img'
-            .is-user-items__others__exhibit__boxes__body
-              %h3.is-user-items__others__exhibit__boxes__body__name その他商品の名前
-              .is-user-items__others__exhibit__boxes__body__price ¥###
-
-        %section.is-user-items__others__exhibit__boxes
-          = link_to root_path, class: 'is-user-items__others__exhibit__boxes__link' do
-            %figure.is-user-items__others__exhibit__boxes__photo
-              = image_tag 'frema66img-sample3.jpeg', class: 'is-user-items__others__exhibit__boxes__photo__img'
-            .is-user-items__others__exhibit__boxes__body
-              %h3.is-user-items__others__exhibit__boxes__body__name その他商品の名前
-              .is-user-items__others__exhibit__boxes__body__price ¥###
-
-
+        - @same_category_items.each do |item| 
+          - if item.id != @item.id  # 現在表示している商品は関連に表示しない
+            %section.is-user-items__others__exhibit__boxes
+              = link_to item_path(item.id), class: 'is-user-items__others__exhibit__boxes__link' do
+                %figure.is-user-items__others__exhibit__boxes__photo
+                  - thumbnail = Image.find_by(item_id: item.id) # サムネイルとして商品の先頭に登録されている画像のみを取り出す
+                  = image_tag "#{thumbnail.source}", class: 'is-user-items__others__exhibit__boxes__photo__img'
+                .is-user-items__others__exhibit__boxes__body
+                  %h3.is-user-items__others__exhibit__boxes__body__name 
+                    = item.name
+                  .is-user-items__others__exhibit__boxes__body__price 
+                  ¥
+                  = item.price
 
 
   = render 'shared/footer1'
-
-  -# = icon 'fas', 'angle-right'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -18,17 +18,9 @@
                   .is__photo__place__sample__stage__in__img
                     = image_tag "#{image.source}", size: "300x300"
           .is__photo__place__disabled
-          .is__photo__place__dots
-            .is__photo__place__dots__inner
-            .is__photo__place__dots__inner
-            .is__photo__place__dots__inner
-            .is__photo__place__dots__inner
-            .is__photo__place__dots__inner
-            .is__photo__place__dots__inner
-            .is__photo__place__dots__inner
-            .is__photo__place__dots__inner
-            .is__photo__place__dots__inner
-            .is__photo__place__dots__inner
+          #is__photo__place__dots
+            - @item.images.each do |image|
+              = image_tag "#{image.source}", size: "80x80"
 
       %table.is__table
         %tbody


### PR DESCRIPTION
# What
商品詳細ページで登録されている商品情報を表示できるようにした。
出品者の他の出品商品、出品商品と同ジャンルの商品の一覧を表示するようにした

# Why
商品詳細を確認できることは必須事項であるため。
関連商品を表示することで顧客の購買意欲を高めるため

## 実装画面

### 概要
[![Image from Gyazo](https://i.gyazo.com/58741ffb7d697e9c224c22173b9ecd1a.gif)](https://gyazo.com/58741ffb7d697e9c224c22173b9ecd1a)

### 商品画像の切替
[![Image from Gyazo](https://i.gyazo.com/94495da7c24e4a86e5e81896b7022a9d.gif)](https://gyazo.com/94495da7c24e4a86e5e81896b7022a9d)

### 関連商品の表示
[![Image from Gyazo](https://i.gyazo.com/4c9430a909c296de3262909e3b6f4a6f.gif)](https://gyazo.com/4c9430a909c296de3262909e3b6f4a6f)