### PR TITLE
ユーザー新規登録における各ページごとのバリデーションチェックの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ gem 'mini_magick'
 gem 'font-awesome-sass'
 gem 'haml-rails'
 gem 'fog-aws'
+gem 'rails-i18n' #エラーメッセージ日本語化
 
 # authentication with other service
 gem 'omniauth'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -261,6 +261,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.4.1)
       actionpack (= 5.2.4.1)
       activesupport (= 5.2.4.1)
@@ -389,6 +392,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-i18n
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,14 +9,11 @@
 @import "user/devise-session-new";
 @import "modules/show.scss";
 @import "items/new";
-
 @import "items/search";
 @import "modules/header2.scss";
 @import "modules/footer2.scss";
-
 @import "modules/header2";
 @import "modules/footer2";
-
 @import "mypages/mypages_edit.scss";
 @import "modules/side-bar";
 @import "modules/main";
@@ -30,6 +27,7 @@
 @import "purchase/purchase_index.scss";
 @import "modules/bread";
 @import "mypages/on_sale";
+@import "modules/devise-error";
 
 body {
   background-color: $main_color;

--- a/app/assets/stylesheets/modules/_devise-error.scss
+++ b/app/assets/stylesheets/modules/_devise-error.scss
@@ -1,0 +1,3 @@
+.devise-error{
+  color: red;
+}

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -18,7 +18,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
     session[:after_new_user] = user_params[:personal_datum_attributes]
     @user = User.new(session[:user_params])
     @user.build_personal_datum(session[:after_new_user])
-    render :new_phone
+    @user.personal_datum[:phone_number] = "00000"
+    if @user.valid?(:validates_create_user)
+      render :new_phone 
+    else
+      @user.errors
+      @errors = @user.errors.full_messages 
+      render :new, params: @errors
+    end
   end
 
   def new_phone
@@ -29,9 +36,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create_phone
     session[:after_create_phone]= user_params[:personal_datum_attributes]
     session[:after_create_phone].merge!(session[:after_new_user])
-    @user = User.new
+    @user = User.new(email: "dammy@mail.com", password: "dammypassword010")
     @user.build_personal_datum(session[:after_create_phone])
-    render :new_address
+    if @user.valid?(:validates_create_phone)
+      render :new_address
+    else
+      @user.errors 
+      @errors = @user.errors.full_messages 
+      render :new_phone, params: @errors
+    end
   end
 
   def new_address
@@ -41,9 +54,15 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def create_address
     session[:after_create_address]= user_params[:address_attributes]
-    @user = User.new
+    @user = User.new(email: "dammy@mail.com", password: "dammypassword010")
     @user.build_address(session[:after_create_address])
-    render :new_card
+    if @user.valid?(:validates_create_address)
+      render :new_card
+    else
+      @user.errors 
+      @errors = @user.errors.full_messages 
+      render :new_address, params: @errors
+    end
   end
 
   def new_card

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,11 +1,11 @@
 class Address < ApplicationRecord
 
   # validation
-  validates :postal_code,             presence: true, length: {maximum: 10}, format: {with: /\A[0-9]{7}\z/}
-  validates :prefecture,              presence: true, length: {maximum: 30}
-  validates :municipality,            presence: true, length: {maximum: 30}
-  validates :house_number,            presence: true, length: {maximum: 100}
-  validates :building_name,           length: {maximum: 100}
+  validates :postal_code,             presence: true, length: {maximum: 10}, format: {with: /\A[0-9]{7}\z/, message: "は半角数字, ハイフンなし7桁で入力してください"}, on: :validates_create_address
+  validates :prefecture,              presence: true, length: {maximum: 30}, on: :validates_create_address
+  validates :municipality,            presence: true, length: {maximum: 30}, on: :validates_create_address
+  validates :house_number,            presence: true, length: {maximum: 100}, on: :validates_create_address
+  validates :building_name,           length: {maximum: 100}, on: :validates_create_address
 
   # assosiation
   belongs_to :user, optional: true

--- a/app/models/personal_datum.rb
+++ b/app/models/personal_datum.rb
@@ -1,14 +1,14 @@
 class PersonalDatum < ApplicationRecord
 
   # validation
-  validates :first_name,            presence: true, length: {maximum: 20}
-  validates :last_name,             presence: true, length: {maximum: 20}
-  validates :kana_first_name,       presence: true, length: {maximum: 20}
-  validates :kana_last_name,        presence: true, length: {maximum: 20}
-  validates :birthday_year,         presence: true
-  validates :birthday_month,        presence: true
-  validates :birthday_day,          presence: true
-  validates :phone_number,          presence: true, length: {maximum: 20}
+  validates :first_name,            presence: true, length: {maximum: 20}, on: :validates_create_user
+  validates :last_name,             presence: true, length: {maximum: 20}, on: :validates_create_user
+  validates :kana_first_name,       presence: true, length: {maximum: 20}, on: :validates_create_user
+  validates :kana_last_name,        presence: true, length: {maximum: 20}, on: :validates_create_user
+  validates :birthday_year,         presence: true, on: :validates_create_user
+  validates :birthday_month,        presence: true, on: :validates_create_user
+  validates :birthday_day,          presence: true, on: :validates_create_user
+  validates :phone_number,          presence: true, length: {maximum: 20}, on: :validates_create_phone
   
   # assosiation
   belongs_to :user, optional: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,9 +5,9 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
 
   # validation
-  validates :email,                 presence: true, uniqueness: { case_sensitive: false }, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
-  validates :password,              presence: true, length: {minimum: 7, maximum: 128},    format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{7,128}+\z/i }
-  validates :nickname,              presence: true, length: {maximum: 10}
+  validates :email,                 presence: true, uniqueness: { case_sensitive: false }, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i, message: "は半角英数字で'~~~@~~.~~'の形式で入力してください" }, on: :validates_create_user
+  validates :password,              presence: true, length: {minimum: 7, maximum: 128},    format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]{7,128}+\z/i, message: "は半角英数字で、英字と数字を両方含めて設定してください" }, on: :validates_create_user
+  validates :nickname,              presence: true, length: {maximum: 10}, on: :validates_create_user
 
   # assosiation
   has_one :address, dependent: :destroy

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -6,6 +6,8 @@
   .urn-main__forms
     .urn-main__forms__single-content
       = form_for @user, url: create_user_path, method: :post do |f|
+        .devise-error
+          = render 'devise/shared/error_messages', model: f.object
         .urn-main__forms__single-content__group.urn-main__forms__single-content__group--top
           .urn-label  
             ニックネーム
@@ -24,7 +26,7 @@
           .urn-require
             必須
           = f.password_field :password, autocomplete: "new-password", class: "urn-form", placeholder: "7文字以上の半角英数字"
-          %p.urn-form-info-text ※ 英数字と数字の両方を含めて設定してください
+          %p.urn-form-info-text ※ 英字と数字の両方を含めて設定してください
         .urn-main__forms__single-content__group
           %h3 本人確認
           %p 安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客様に公開されることはありません。 

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -7,6 +7,8 @@
     .urn-main__forms__single-content
       = form_for @user, url: create_address_path do |f|
         = f.fields_for :address_attributes do |fin|
+          .devise-error
+            = render 'devise/shared/error_messages', model: f.object
           .urn-main__forms__single-content__group.urn-main__forms__single-content__group--top
             .urn-div
               .urn-label  

--- a/app/views/devise/registrations/new_phone.html.haml
+++ b/app/views/devise/registrations/new_phone.html.haml
@@ -8,6 +8,8 @@
     .urn-main__forms__single-content
       = form_for @user, url: create_phone_path, mehod: :post do |f|
         = f.fields_for :personal_datum do |fin|
+          .devise-error
+            = render 'devise/shared/error_messages', model: f.object
           .urn-main__forms__single-content__group.urn-main__forms__single-content__group--top
             .urn-div
               .urn-label

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module FreemarketSample66d
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,64 @@
+ja:
+  errors:
+    messages:
+      not_found: "は見つかりませんでした"
+#      not_found: "not found"
+      already_confirmed: "は既に登録済みです"
+#      already_confirmed: "was already confirmed"
+      not_locked: "は凍結されていません"
+#      not_locked: "was not locked"
+      not_saved: "以下の項目を再入力してください"
+
+  devise:
+    failure:
+      unauthenticated: 'ログインしてください。'
+#      unauthenticated: 'You need to sign in or sign up before continuing.'
+      unconfirmed: '本登録を行ってください。'
+#      unconfirmed: 'You have to confirm your account before continuing.'
+      locked: 'あなたのアカウントは凍結されています。'
+#      locked: 'Your account is locked.'
+      invalid: 'メールアドレスかパスワードが違います。'
+#      invalid: 'Invalid email or password.'
+      invalid_token: '認証キーが不正です。'
+#      invalid_token: 'Invalid authentication token.'
+      timeout: 'セッションがタイムアウトしました。もう一度ログインしてください。'
+#      timeout: 'Your session expired, please sign in again to continue.'
+      inactive: 'アカウントがアクティベートされていません。'
+#      inactive: 'Your account was not activated yet.'
+    sessions:
+      signed_in: 'ログインしました。'
+#      signed_in: 'Signed in successfully.'
+      signed_out: 'ログアウトしました。'
+#      signed_out: 'Signed out successfully.'
+    passwords:
+      send_instructions: 'パスワードのリセット方法を数分以内にメールでご連絡します。'
+#      send_instructions: 'You will receive an email with instructions about how to reset your password in a few minutes.'
+      updated: 'パスワードを変更しました。'
+#      updated: 'Your password was changed successfully. You are now signed in.'
+    confirmations:
+      send_instructions: '登録方法を数分以内にメールでご連絡します。'
+#      send_instructions: 'You will receive an email with instructions about how to confirm your account in a few minutes.'
+      confirmed: 'アカウントを登録しました。'
+#      confirmed: 'Your account was successfully confirmed. You are now signed in.'
+    registrations:
+      signed_up: 'アカウント登録を受け付けました。確認のメールをお送りします。'
+#      signed_up: 'You have signed up successfully. If enabled, a confirmation was sent to your e-mail.'
+      updated: 'アカウントを更新しました。'
+#      updated: 'You updated your account successfully.'
+      destroyed: 'アカウントを削除しました。またのご利用をお待ちしております。'
+#      destroyed: 'Bye! Your account was successfully cancelled. We hope to see you again soon.'
+    unlocks:
+      send_instructions: 'アカウントの凍結解除方法を数分以内にメールでご連絡します。'
+#      send_instructions: 'You will receive an email with instructions about how to unlock your account in a few minutes.'
+      unlocked: 'アカウントを凍結解除しました。'
+#      unlocked: 'Your account was successfully unlocked. You are now signed in.'
+    mailer:
+      confirmation_instructions:
+        subject: 'アカウントの登録方法'
+#        subject: 'Confirmation instructions'
+      reset_password_instructions:
+        subject: 'パスワードの再設定'
+#        subject: 'Reset password instructions'
+      unlock_instructions:
+        subject: 'アカウントの凍結解除'
+#        subject: 'Unlock Instructions'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,20 @@
+ja:
+  activerecord:
+    attributes:
+        user: 
+          email: メールアドレス
+          contents: パスワード
+          nickname: ニックネーム
+          password: パスワード
+        personal_datum:
+          first_name: お名前
+          last_name: お名前
+          kana_first_name: お名前カナ
+          kana_last_name: お名前カナ
+          phone_number: 電話番号
+        address:
+          postal_code: 郵便番号
+          prefecture: 都道府県
+          municipality: 市区町村
+          house_number: 番地
+          


### PR DESCRIPTION
# What
ユーザー新規登録画面において各ページ(会員情報, 電話番号, 住所)ごとにバリデーション違反を確認するようにした
違反があった場合エラーメッセージを表示し再び入力を求めるようにした
エラーメッセージを日本語化した

# Why
ユーザー登録をスムーズなものにするため
どの項目が違反しているのかを明確にユーザーに伝えるため

## エラー画面
全てのフォームを未入力で次に進もうとした場合のエラー表示

### 会員情報登録画面
[![Image from Gyazo](https://i.gyazo.com/f415bb7aef1d9d3ebc67738d0849cff4.png)](https://gyazo.com/f415bb7aef1d9d3ebc67738d0849cff4)

### 電話番号の確認
[![Image from Gyazo](https://i.gyazo.com/654723c2bd525137132c93682d0ac1a1.png)](https://gyazo.com/654723c2bd525137132c93682d0ac1a1)

### お届け先住所
[![Image from Gyazo](https://i.gyazo.com/c476184dba4d372083268c8c9850cbbb.png)](https://gyazo.com/c476184dba4d372083268c8c9850cbbb)